### PR TITLE
add fish shell info

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ $ time ( for _ in {1..10}; do tag EXPORT_SYMBOL_GPL >/dev/null 2>&1; done )
       fi
       ```
 
+    - `fish - ~/.config/fish/functions/tag.fish`
+      ```fish
+      function tag
+          set -q TAG_ALIAS_FILE; or set -l TAG_ALIAS_FILE /tmp/tag_aliases
+          command tag $argv; and source $TAG_ALIAS_FILE ^/dev/null
+          alias ag tag
+      end
+      ```
+
 # Configuration
 
 tag exposes the following configuration options via environment variables:


### PR DESCRIPTION
Just a small addition for Fish shell syntax. 

Really love this, as I use `ag` all the time. 