### PR TITLE
Add missing semicolon in bash install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ time ( for _ in {1..10}; do tag EXPORT_SYMBOL_GPL >/dev/null 2>&1; done )
     - `bash`
       ```bash
       if hash ag 2>/dev/null; then
-        tag() { command tag "$@"; source ${TAG_ALIAS_FILE:-/tmp/tag_aliases} 2>/dev/null }
+        tag() { command tag "$@"; source ${TAG_ALIAS_FILE:-/tmp/tag_aliases} 2>/dev/null; }
         alias ag=tag
       fi
       ```


### PR DESCRIPTION
Fixes #2