### PR TITLE
Add Arch Linux installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ $ time ( for _ in {1..10}; do tag EXPORT_SYMBOL_GPL >/dev/null 2>&1; done )
       $ brew install tag-ag
       ```
 
+    - AUR (Arch Linux)
+
+      Using your favorite [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers), install the [tag-ag AUR package](https://aur.archlinux.org/packages/tag-ag/) like this:
+      ```
+      $ aura -A tag-ag
+      ```
+
     - [Download a compressed binary for your platform](https://github.com/aykamko/tag/releases)
 
     - Developers and other platforms


### PR DESCRIPTION
I am maintaining a package for tag on Arch Linux in the AUR (Arch Linux User Repository). It would be nice to have it in the README for potential users.

Thanks for your work on this project, it's great!