### PR TITLE
Quote filename

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -26,7 +26,6 @@ var (
 	blue          = color.BlueString
 	pathRe        = regexp.MustCompile(`^(?:\x1b\[[^m]+m)?([^\x1b]+).*`)
 	lineNumberRe  = regexp.MustCompile(`^(?:\x1b\[[^m]+m)?(\d+)(?:\x1b\[0m\x1b\[K)?:.*`)
-	cleanFilename = regexp.MustCompile(`([ \(\)\[\]\<\>])`)
 )
 
 type AliasFile struct {
@@ -49,7 +48,7 @@ func NewAliasFile() *AliasFile {
 
 	aliasCmdFmtString := os.Getenv("TAG_CMD_FMT_STRING")
 	if len(aliasCmdFmtString) == 0 {
-		aliasCmdFmtString = "vim {{.Filename}} +{{.LineNumber}}"
+		aliasCmdFmtString = "vim \"{{.Filename}}\" +{{.LineNumber}}"
 	}
 
 	a := &AliasFile{
@@ -62,8 +61,6 @@ func NewAliasFile() *AliasFile {
 
 func (a *AliasFile) WriteAlias(index int, filename, linenum string) {
 	t := template.Must(template.New("alias").Parse(a.fmtStr))
-
-	filename = cleanFilename.ReplaceAllString(filename, "\\$1")
 
 	aliasVars := struct {
 		MatchIndex int


### PR DESCRIPTION
Instead of cleaning up characters in the filename, quote it.

This solves the case where you have a filename with an ampersand in it,
which previously caused the incorrect file to attempt to be edited, and
then backgrounded that, since the shell captured the symbol.