### PR TITLE
Use more common syntax for Ex commands

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -48,7 +48,7 @@ func NewAliasFile() *AliasFile {
 
 	aliasCmdFmtString := os.Getenv("TAG_CMD_FMT_STRING")
 	if len(aliasCmdFmtString) == 0 {
-		aliasCmdFmtString = "vim '{{.Filename}}' '+call cursor({{.LineNumber}}, {{.ColumnNumber}})'"
+		aliasCmdFmtString = "vim  -c 'call cursor({{.LineNumber}}, {{.ColumnNumber}})' '{{.Filename}}'"
 	}
 
 	a := &AliasFile{


### PR DESCRIPTION
This way is the "approved" way to call a command and also allows chaining commands in case you want to implement that later.